### PR TITLE
Feat : Bulk insert

### DIFF
--- a/PostgrestTests/Api.cs
+++ b/PostgrestTests/Api.cs
@@ -490,5 +490,39 @@ namespace PostgrestTests
                 Assert.IsNull(user.Catchphrase);              
             }
         }
+
+        [TestMethod("insert: bulk")]
+        public async Task TestInsertBulk()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+            var rocketUser = new User
+            {
+                Username = "rocket",
+                AgeRange = new Range(35, 40),
+                Status = "ONLINE"
+            };
+
+            var aceUser = new User
+            {
+                Username = "ace",
+                AgeRange = new Range(21, 28),
+                Status = "OFFLINE"
+            };
+            var users = new List<User>
+            {
+               rocketUser,
+               aceUser
+            };
+
+
+            var response = await client.Table<User>().Insert(users);
+            var insertedUsers = response.Models;
+
+
+            CollectionAssert.AreEqual(users, insertedUsers);
+
+            await client.Table<User>().Delete(rocketUser);
+            await client.Table<User>().Delete(aceUser);
+        }
     }
 }

--- a/PostgrestTests/Models/User.cs
+++ b/PostgrestTests/Models/User.cs
@@ -22,15 +22,13 @@ namespace PostgrestTests.Models
         public override bool Equals(object obj)
         {
             return obj is User user &&
-                   Status == user.Status &&
                    Username == user.Username &&
-                   AgeRange.Equals(user.AgeRange) &&
                    Catchphrase == user.Catchphrase;
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Status, Username, AgeRange, Catchphrase);
+            return HashCode.Combine(Username, Catchphrase);
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature bulk insert

## What is the current behavior?

Feature request #13  

## What is the new behavior?

* Overload the insert method to perform a bulk insert on a table
* PrepareRequestData return object instead of Dictionary<string,string>
* Helpers.MakeRequest method expect data as object instead of Dictionary<string,string>

## Additional context
* **This changes didn't break anything , tests passed perfectly!**

### Usage

```csharp
var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
var rocketUser = new User
            {
                Username = "rocket",
                AgeRange = new Range(35, 40),
                Status = "ONLINE"
            };

var aceUser = new User
            {
                Username = "ace",
                AgeRange = new Range(21, 28),
                Status = "OFFLINE"
            };
var users = new List<User>
            {
               rocketUser,
               aceUser
            };


var response = await client.Table<User>().Insert(users);
```
