### PR TITLE
Fix : contains filter with Range criteria

### DIFF
--- a/Postgrest/QueryFilter.cs
+++ b/Postgrest/QueryFilter.cs
@@ -128,6 +128,7 @@ namespace Postgrest
             switch (op)
             {
                 case Operator.Overlap:
+                case Operator.Contains:
                 case Operator.StrictlyLeft:
                 case Operator.StrictlyRight:
                 case Operator.NotRightOf:

--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -599,6 +599,10 @@ namespace Postgrest
                         {
                             return new KeyValuePair<string, string>(filter.Property, $"{asAttribute.Mapping}.{JsonConvert.SerializeObject(dictCriteria)}");
                         }
+                        else if (filter.Criteria is Range rangeCriteria)
+                        {
+                            return new KeyValuePair<string, string>(filter.Property, $"{asAttribute.Mapping}.{rangeCriteria.ToPostgresString()}");
+                        }
                         break;
                     case Operator.StrictlyLeft:
                     case Operator.StrictlyRight:

--- a/PostgrestTests/Api.cs
+++ b/PostgrestTests/Api.cs
@@ -693,6 +693,17 @@ namespace PostgrestTests
             CollectionAssert.AreEqual(linqFilteredMessages, supaFilteredMessages);
         }
 
+        [TestMethod("filters: cs")]
+        public async Task TestContainsFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            await client.Table<User>().Insert(new User { Username = "skikra", Status = "ONLINE", AgeRange = new Range(1,3) }, new InsertOptions { Upsert = true });
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.Contains, new Range(1,2)).Get();
+
+            Assert.AreEqual(1, filteredResponse.Models.Count);
+        }
+
         [TestMethod("filters: ilike")]
         public async Task TestILikeFilter()
         {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Part #18 mentioned also in #17

## What is the new behavior?

* Accept Range criteria with contains operator
* Successful filter request with Range and contains operator

