### PR TITLE
Fix Contained filter with Range Criteria and add unit tests

### DIFF
--- a/Postgrest/QueryFilter.cs
+++ b/Postgrest/QueryFilter.cs
@@ -129,6 +129,7 @@ namespace Postgrest
             {
                 case Operator.Overlap:
                 case Operator.Contains:
+                case Operator.ContainedIn:
                 case Operator.StrictlyLeft:
                 case Operator.StrictlyRight:
                 case Operator.NotRightOf:

--- a/PostgrestTests/Api.cs
+++ b/PostgrestTests/Api.cs
@@ -704,6 +704,16 @@ namespace PostgrestTests
             Assert.AreEqual(1, filteredResponse.Models.Count);
         }
 
+        [TestMethod("filters: cd")]
+        public async Task TestContainedFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.ContainedIn, new Range(25, 35)).Get();
+
+            Assert.AreEqual(2, filteredResponse.Models.Count);
+        }
+
         [TestMethod("filters: ilike")]
         public async Task TestILikeFilter()
         {

--- a/PostgrestTests/Api.cs
+++ b/PostgrestTests/Api.cs
@@ -714,6 +714,66 @@ namespace PostgrestTests
             Assert.AreEqual(2, filteredResponse.Models.Count);
         }
 
+        [TestMethod("filters: sr")]
+        public async Task TestStrictlyLeftFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.StrictlyLeft, new Range(2, 26)).Get();
+
+            Assert.AreEqual(1, filteredResponse.Models.Count);
+        }
+
+        [TestMethod("filters: sl")]
+        public async Task TestStrictlyRightFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.StrictlyRight, new Range(1, 2)).Get();
+
+            Assert.AreEqual(5, filteredResponse.Models.Count);
+        }
+
+        [TestMethod("filters: nxl")]
+        public async Task TestNotExtendToLeftFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.NotLeftOf, new Range(2, 4)).Get();
+
+            Assert.AreEqual(5, filteredResponse.Models.Count);
+        }
+
+        [TestMethod("filters: nxr")]
+        public async Task TestNotExtendToRightFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.NotRightOf, new Range(2, 4)).Get();
+
+            Assert.AreEqual(2, filteredResponse.Models.Count);
+        }
+
+        [TestMethod("filters: adj")]
+        public async Task TestAdjacentFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.Adjacent, new Range(1, 2)).Get();
+
+            Assert.AreEqual(2, filteredResponse.Models.Count);
+        }
+
+        [TestMethod("filters: ov")]
+        public async Task TestOverlapFilter()
+        {
+            var client = Client.Instance.Initialize(baseUrl, new ClientAuthorization(AuthorizationType.Open, null));
+
+            var filteredResponse = await client.Table<User>().Filter("age_range", Operator.Overlap, new Range(2, 4)).Get();
+
+            Assert.AreEqual(2, filteredResponse.Models.Count);
+        }
+
         [TestMethod("filters: ilike")]
         public async Task TestILikeFilter()
         {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Buf fix and chore unit tests

## What is the current behavior?

* Same as #19 Contained filter behaved same as contains operator with Range criteria

## What is the new behavior?

* Allowing Contained operator with Range criteria
* Add units tests for : sl, sr, nxl, nxr, adj, ov filters

