### PR TITLE
Chore : Filter exception message and Match filter docs

### DIFF
--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -197,6 +197,11 @@ namespace Postgrest
             return this;
         }
 
+        /// <summary>
+        /// Finds all rows whose columns match the specified `query` object.
+        /// </summary>
+        /// <param name="query">The object to filter with, with column names as keys mapped to their filter values.</param>
+        /// <returns></returns>
         public Table<T> Match(Dictionary<string, string> query)
         {
             foreach (var param in query)

--- a/Postgrest/Table.cs
+++ b/Postgrest/Table.cs
@@ -125,7 +125,7 @@ namespace Postgrest
                 return this;
             }
 
-            throw new Exception("Unknown criterion type, is it of type `string`, `List`, `Dictionary<string, object>`, or `Range`?");
+            throw new Exception("Unknown criterion type, is it of type `string`, `List`, `Dictionary<string, object>`, `FullTextSearchConfig`, or `Range`?");
         }
 
         /// <summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore, my bad I forgot to add it in previous PR

## What is the current behavior?

* Missing FullTextSearchConfig object in exception message that is thrown when calling Filter with unallowed type
* No documentation for Match method

## What is the new behavior?

* Add FullTextSearchConfig to exception message
* Add documentation for Match filter

